### PR TITLE
Removing argument 'is_train' which is not used in SeqDecoder.finalise_minibatch

### DIFF
--- a/Models/exprsynth/seq2seqmodel.py
+++ b/Models/exprsynth/seq2seqmodel.py
@@ -83,7 +83,7 @@ class Seq2SeqModel(ContextTokenModel):
 
     def _finalise_minibatch(self, batch_data: Dict[str, Any], is_train: bool) -> Dict[tf.Tensor, Any]:
         minibatch = super()._finalise_minibatch(batch_data, is_train)
-        self._decoder_model.finalise_minibatch(batch_data, minibatch, is_train)
+        self._decoder_model.finalise_minibatch(batch_data, minibatch)
         return minibatch
 
     # ------- These are the bits that we only need for test-time:

--- a/Models/exprsynth/seqdecoder.py
+++ b/Models/exprsynth/seqdecoder.py
@@ -290,7 +290,7 @@ class SeqDecoder(object):
         batch_data['target_token_ids'].append(sample['target_token_ids'])
         batch_data['target_token_ids_mask'].append(sample['target_token_ids_mask'])
 
-    def finalise_minibatch(self, batch_data: Dict[str, Any], minibatch: Dict[tf.Tensor, Any], is_train: bool) -> None:
+    def finalise_minibatch(self, batch_data: Dict[str, Any], minibatch: Dict[tf.Tensor, Any]) -> None:
         write_to_minibatch(minibatch, self.placeholders['target_token_ids'], batch_data['target_token_ids'])
         write_to_minibatch(minibatch, self.placeholders['target_token_ids_mask'], batch_data['target_token_ids_mask'])
 


### PR DESCRIPTION
This argument raises an exception because: 
* `SeqDecoder.finalise_minibatch(..)` requires a named argument `is_train`, but does not use it
* `Seq2SeqModel` calls `self._decoder_model.finalise_metadata` **with** `is_train`
* `Graph2SeqModel` calls `self._decoder_model.finalise_metadata` **without** `is_train` (so it is currently broken)

By removing this unused argument, Graph2Seq is fixed.