### PR TITLE
add config——System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/DataExtraction/ExpressionDataExtractor/ExpressionDataExtractor.csproj
+++ b/DataExtraction/ExpressionDataExtractor/ExpressionDataExtractor.csproj
@@ -17,5 +17,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" version="2.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" version="2.10.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Environment Visual Studio 2019. When I was debugging the `DataEtraction/ExpressionDataExtractor` project, An exception occurred on `workspace.OpenSolutionAsync(solutionPath).Result` of `CSharpCorpusBuilder.cs`'s line 92.

The error message was that `"System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1" was not found`, and I solved the problem after adding a PackageReference to the project, so I submitted the pull request.

Thanks for your projects.